### PR TITLE
Feat/#1 auth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,11 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+	implementation 'com.google.auth:google-auth-library-oauth2-http:1.16.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/todolist/auth/UserDetailsImpl.java
+++ b/src/main/java/com/example/todolist/auth/UserDetailsImpl.java
@@ -1,0 +1,57 @@
+package com.example.todolist.auth;
+
+import com.example.todolist.user.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class UserDetailsImpl implements UserDetails {
+
+    private final User user;
+
+    public UserDetailsImpl(User user) {
+        this.user = user;
+    }
+
+    public User getUser() {
+        return this.user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(user.getRole().name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/example/todolist/auth/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/todolist/auth/UserDetailsServiceImpl.java
@@ -1,0 +1,27 @@
+package com.example.todolist.auth;
+
+import com.example.todolist.global.excetion.CustomException;
+import com.example.todolist.global.excetion.ErrorCode;
+import com.example.todolist.user.entity.User;
+import com.example.todolist.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserDetailsServiceImpl implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND)
+        );
+        return new UserDetailsImpl(user);
+    }
+}

--- a/src/main/java/com/example/todolist/auth/controller/AuthController.java
+++ b/src/main/java/com/example/todolist/auth/controller/AuthController.java
@@ -1,0 +1,82 @@
+    package com.example.todolist.auth.controller;
+
+    import com.example.todolist.auth.dto.LoginRequestDto;
+    import com.example.todolist.auth.dto.LoginResponseDto;
+    import com.example.todolist.auth.dto.SignupRequestDto;
+    import com.example.todolist.auth.dto.SignupResponseDto;
+    import com.example.todolist.auth.service.LoginService;
+    import com.example.todolist.auth.service.LogoutService;
+    import com.example.todolist.auth.service.SignupService;
+    import com.example.todolist.global.dto.CommonResponse;
+    import com.example.todolist.global.excetion.CustomException;
+    import io.swagger.v3.oas.annotations.Operation;
+    import io.swagger.v3.oas.annotations.tags.Tag;
+    import jakarta.servlet.http.HttpServletRequest;
+    import jakarta.validation.Valid;
+    import org.springframework.beans.factory.annotation.Autowired;
+    import org.springframework.http.HttpStatus;
+    import org.springframework.http.ResponseEntity;
+    import org.springframework.validation.BindingResult;
+    import org.springframework.web.bind.annotation.PostMapping;
+    import org.springframework.web.bind.annotation.RequestBody;
+    import org.springframework.web.bind.annotation.RequestMapping;
+    import org.springframework.web.bind.annotation.RestController;
+
+    @RestController
+    @RequestMapping("/api/auth")
+    @Tag(name = "Auth")
+    public class AuthController {
+
+        @Autowired
+        private SignupService signupService;
+
+        @Autowired
+        private LoginService loginService;
+
+        @Autowired
+        private LogoutService logoutService;
+
+        @PostMapping("/signup")
+        @Operation(summary = "회원가입", description = "회원가입 기능")
+        public ResponseEntity<CommonResponse<SignupResponseDto>> signup(
+                @Valid @RequestBody SignupRequestDto signupRequestDto,
+                BindingResult bindingResult
+        ) {
+            if (bindingResult.hasErrors()) {
+                return ResponseEntity.badRequest()
+                        .body(new CommonResponse<>(bindingResult.getAllErrors().get(0).getDefaultMessage(), 400, null));
+            }
+            SignupResponseDto responseDto = signupService.signup(signupRequestDto);
+            return ResponseEntity.ok(new CommonResponse<>("회원가입 성공", 200, responseDto));
+        }
+
+        @PostMapping("/login")
+        @Operation(summary = "로그인", description = "로그인 기능")
+        public ResponseEntity<CommonResponse> login(
+                @RequestBody LoginRequestDto loginRequestDto
+        ){
+            try {
+                LoginResponseDto responseDto = loginService.login(loginRequestDto);
+                CommonResponse response = new CommonResponse<>("로그인 성공", 200, responseDto);
+                return ResponseEntity.ok(response);
+            } catch (Exception e) {
+                CommonResponse response = new CommonResponse<>("로그인 실패", 500, null);
+                return ResponseEntity.status(500).body(response);
+            }
+        }
+
+        @PostMapping("/logout")
+        @Operation(summary = "로그아웃", description = "로그아웃 기능")
+        public ResponseEntity<CommonResponse<Void>> logout(HttpServletRequest request) {
+            try {
+                CommonResponse<Void> response = logoutService.logout(request);
+                return ResponseEntity.ok(response);
+            } catch (CustomException e) {
+                CommonResponse<Void> response = new CommonResponse<>(e.getMessage(), e.getStatusCode().value(), null);
+                return ResponseEntity.status(e.getStatusCode()).body(response);
+            } catch (Exception e) {
+                CommonResponse<Void> response = new CommonResponse<>("로그아웃 실패", HttpStatus.INTERNAL_SERVER_ERROR.value(), null);
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+            }
+        }
+    }

--- a/src/main/java/com/example/todolist/auth/controller/TokenController.java
+++ b/src/main/java/com/example/todolist/auth/controller/TokenController.java
@@ -1,0 +1,31 @@
+package com.example.todolist.auth.controller;
+
+import com.example.todolist.auth.service.TokenService;
+import com.example.todolist.global.dto.CommonResponse;
+import com.example.todolist.user.entity.TokenStore;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@Tag(name = "Auth")
+public class TokenController {
+
+    @Autowired
+    private TokenService tokenService;
+
+    @PostMapping("/refresh")
+    @Operation(summary = "토큰연장", description = "로그인 연장기능")
+    public ResponseEntity<CommonResponse<TokenStore>> refreshAccessToken(
+            @RequestHeader("Authorization") String refreshTokenHeader
+    ) {
+        TokenStore tokenStore = tokenService.refreshAccessToken(refreshTokenHeader);
+        return ResponseEntity.ok(new CommonResponse<>("로그인 연장 성공",200, tokenStore));
+    }
+}

--- a/src/main/java/com/example/todolist/auth/dto/LoginRequestDto.java
+++ b/src/main/java/com/example/todolist/auth/dto/LoginRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.todolist.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginRequestDto {
+    private String username;
+    private String password;
+}

--- a/src/main/java/com/example/todolist/auth/dto/LoginResponseDto.java
+++ b/src/main/java/com/example/todolist/auth/dto/LoginResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.todolist.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginResponseDto {
+
+    private String AccessToken;
+    private String refreshToken;
+
+    public LoginResponseDto(String accessToken, String refreshToken) {
+        this.AccessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/example/todolist/auth/dto/SignupRequestDto.java
+++ b/src/main/java/com/example/todolist/auth/dto/SignupRequestDto.java
@@ -1,0 +1,26 @@
+package com.example.todolist.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SignupRequestDto {
+
+    @NotBlank(message = "아이디는 필수 입력값입니다.")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[0-9]).{4,10}$",
+            message = "아이디는 최소 4자 이상, 10자 이하이며 알파벳 소문자(a~z), 숫자(0~9)로 이루어져야 합니다.")
+    private String username;
+
+    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$",
+            message = "비밀번호는 최소 8자 이상, 15자 이하이며 알파벳 대소문자, 숫자(0~9), 특수문자(!@#$%^*+=-)를 포함해야 합니다.")
+    private String password;
+
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Pattern(regexp = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$",
+            message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+}

--- a/src/main/java/com/example/todolist/auth/dto/SignupResponseDto.java
+++ b/src/main/java/com/example/todolist/auth/dto/SignupResponseDto.java
@@ -1,0 +1,11 @@
+package com.example.todolist.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SignupResponseDto {
+    private String username;
+    private String email;
+}

--- a/src/main/java/com/example/todolist/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/todolist/auth/security/config/SecurityConfig.java
@@ -1,0 +1,73 @@
+package com.example.todolist.auth.security.config;
+
+import com.example.todolist.auth.security.filter.JwtAuthenticationFilter;
+import com.example.todolist.auth.security.filter.JwtAuthorizationFilter;
+import com.example.todolist.auth.security.jwt.JwtUtil;
+import com.example.todolist.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final UserDetailsService userDetailsService;
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager() throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
+        return new JwtAuthenticationFilter(authenticationManager(), jwtUtil, userRepository);
+    }
+
+    @Bean
+    public JwtAuthorizationFilter jwtAuthorizationFilter() {
+        return new JwtAuthorizationFilter(userDetailsService, jwtUtil, userRepository);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity.csrf((csrf) -> csrf.disable());
+
+        httpSecurity.sessionManagement((sessionManagement) ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        );
+
+        httpSecurity.authorizeHttpRequests((authorizeRequest) ->
+                authorizeRequest
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers(HttpMethod.GET).permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/api-docs/**", "/swagger-resources/**").permitAll()
+                        .anyRequest().authenticated()
+        );
+
+        httpSecurity.addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);
+        httpSecurity.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        return httpSecurity.build();
+    }
+}

--- a/src/main/java/com/example/todolist/auth/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/todolist/auth/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,112 @@
+package com.example.todolist.auth.security.filter;
+
+import com.example.todolist.auth.dto.LoginRequestDto;
+import com.example.todolist.auth.dto.LoginResponseDto;
+import com.example.todolist.auth.security.jwt.JwtUtil;
+import com.example.todolist.global.excetion.CustomException;
+import com.example.todolist.global.excetion.ErrorCode;
+import com.example.todolist.user.entity.TokenStore;
+import com.example.todolist.user.entity.User;
+import com.example.todolist.user.entity.UserRole;
+import com.example.todolist.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import java.io.IOException;
+import java.util.Map;
+
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public JwtAuthenticationFilter(AuthenticationManager authenticationManager, JwtUtil jwtUtil, UserRepository userRepository) {
+        super.setAuthenticationManager(authenticationManager);
+        this.jwtUtil = jwtUtil;
+        this.userRepository = userRepository;
+
+        setFilterProcessesUrl("/api/auth/login");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        try {
+            LoginRequestDto requestDto = objectMapper.readValue(request.getInputStream(), LoginRequestDto.class);
+
+            return getAuthenticationManager().authenticate(
+                    new UsernamePasswordAuthenticationToken(requestDto.getUsername(), requestDto.getPassword(), null)
+            );
+        } catch (IOException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
+        String username = ((UserDetails) authResult.getPrincipal()).getUsername();
+
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USERNAME));
+
+        UserRole role = user.getRole();
+
+        String accessToken = jwtUtil.createToken(username, role, JwtUtil.ACCESS_TOKEN_EXPIRATION);
+        String refreshToken = jwtUtil.createToken(username, role, JwtUtil.REFRESH_TOKEN_EXPIRATION);
+
+        saveRefreshToken(user, refreshToken);
+
+        LoginResponseDto loginResponseDto = LoginResponseDto.builder()
+                .AccessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+
+        response.addHeader(JwtUtil.AUTHORIZATION_HEADER, "Bearer " + accessToken); // "Bearer " 추가
+        responseSetting(response, HttpServletResponse.SC_OK, loginResponseDto);
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException {
+        if (failed instanceof BadCredentialsException) {
+            responseSetting(response, HttpServletResponse.SC_UNAUTHORIZED,
+                    Map.of("message", "로그인 실패: 비밀번호가 일치하지 않습니다."));
+        } else if (failed instanceof UsernameNotFoundException) {
+            responseSetting(response, HttpServletResponse.SC_UNAUTHORIZED,
+                    Map.of("message", "로그인 실패: 아이디를 찾을 수 없습니다."));
+        } else {
+            responseSetting(response, HttpServletResponse.SC_UNAUTHORIZED,
+                    Map.of("message", "로그인 실패: 인증에 실패했습니다."));
+        }
+    }
+
+    private void saveRefreshToken(User user, String refreshToken) {
+        String pureRefreshToken = refreshToken.replace("Bearer ", "");
+
+        if (user.getTokenStore() == null) {
+            user.setTokenStore(TokenStore.builder()
+                    .refreshToken(pureRefreshToken)
+                    .build());
+        } else {
+            user.getTokenStore().setRefreshToken(pureRefreshToken);
+        }
+
+        userRepository.save(user);
+    }
+
+    private void responseSetting(HttpServletResponse response, int status, Object responseObject) throws IOException {
+        response.setStatus(status);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(responseObject));
+    }
+}

--- a/src/main/java/com/example/todolist/auth/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/example/todolist/auth/security/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,52 @@
+package com.example.todolist.auth.security.filter;
+
+import com.example.todolist.auth.security.jwt.JwtUtil;
+import com.example.todolist.user.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final UserDetailsService userDetailsService;
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        try {
+            String token = jwtUtil.getJwtTokenFromHeader(request);
+
+            if (token != null && jwtUtil.isTokenValid(token)) {
+                Claims claims = jwtUtil.getUserInfoFromToken(token);
+                String username = claims.getSubject(); // subject = username
+
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+
+        } catch (Exception e) {
+            System.err.println("JWT 인증 실패: " + e.getMessage());
+        }
+
+        chain.doFilter(request, response);
+    }
+
+}

--- a/src/main/java/com/example/todolist/auth/security/jwt/JwtUtil.java
+++ b/src/main/java/com/example/todolist/auth/security/jwt/JwtUtil.java
@@ -1,0 +1,88 @@
+package com.example.todolist.auth.security.jwt;
+
+import com.example.todolist.global.excetion.CustomException;
+import com.example.todolist.global.excetion.ErrorCode;
+import com.example.todolist.user.entity.UserRole;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    public static final Long ACCESS_TOKEN_EXPIRATION =  2* 60 * 60 * 1000L; // 2시간
+    public static final Long REFRESH_TOKEN_EXPIRATION = 24 * 60 * 60 * 1000L; // 1일
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final Key key;
+
+    public JwtUtil(@Value("${jwt.secret}") String secretKey) {
+        if (secretKey == null || secretKey.isBlank()) {
+            throw new IllegalArgumentException("환경 변수 JWT_SECRET_KEY가 설정되지 않았습니다.");
+        }
+        byte[] keyBytes = Base64.getDecoder().decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createToken(String username, UserRole role, Long expiresIn) {
+        Date date = new Date(System.currentTimeMillis() + expiresIn);
+
+        Claims claims = Jwts.claims().setSubject(username);
+        claims.put("role", role);
+
+        return BEARER_PREFIX + Jwts.builder()
+                .setClaims(claims)
+                .setExpiration(date)
+                .setIssuedAt(new Date())
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String getJwtTokenFromHeader(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (bearerToken == null || !bearerToken.startsWith(BEARER_PREFIX)) {
+            return null;
+        }
+        return bearerToken.substring(7);
+    }
+
+    public void validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+        } catch (SecurityException | MalformedJwtException | SignatureException e) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(ErrorCode.TOKEN_EXPIRATION);
+        } catch (UnsupportedJwtException e) {
+            throw new CustomException(ErrorCode.NOT_SUPPORTED_TOKEN);
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.FALSE_TOKEN);
+        }
+    }
+
+    public Claims getUserInfoFromToken(String token) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    public boolean isTokenValid(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/com/example/todolist/auth/service/LoginService.java
+++ b/src/main/java/com/example/todolist/auth/service/LoginService.java
@@ -1,0 +1,54 @@
+package com.example.todolist.auth.service;
+
+import com.example.todolist.auth.dto.LoginRequestDto;
+import com.example.todolist.auth.dto.LoginResponseDto;
+import com.example.todolist.auth.security.jwt.JwtUtil;
+import com.example.todolist.global.excetion.CustomException;
+import com.example.todolist.global.excetion.ErrorCode;
+import com.example.todolist.user.entity.TokenStore;
+import com.example.todolist.user.entity.User;
+import com.example.todolist.user.entity.UserRole;
+import com.example.todolist.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LoginService {
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    private final PasswordEncoder passwordEncoder;
+
+    public LoginResponseDto login(LoginRequestDto loginRequestDto) {
+        String username = loginRequestDto.getUsername();
+        String password = loginRequestDto.getPassword();
+
+        User loginUser = userRepository.findByUsername(username).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND_USERNAME)
+        );
+
+        if(!passwordEncoder.matches(password, loginUser.getPassword())){
+            System.out.println("비밀번호 불일치");
+            throw new CustomException(ErrorCode.BAD_REQUEST);
+        }
+
+        UserRole role = loginUser.getRole();
+
+        String accessToken = jwtUtil.createToken(username, role,JwtUtil.ACCESS_TOKEN_EXPIRATION);
+        String refreshToken = jwtUtil.createToken(username, role, JwtUtil.REFRESH_TOKEN_EXPIRATION);
+
+
+        if (loginUser.getTokenStore() == null) {
+            loginUser.setTokenStore(new TokenStore(refreshToken));
+        } else {
+            loginUser.getTokenStore().setRefreshToken(refreshToken);
+        }
+
+        userRepository.save(loginUser);
+
+        return new LoginResponseDto(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/example/todolist/auth/service/LogoutService.java
+++ b/src/main/java/com/example/todolist/auth/service/LogoutService.java
@@ -1,0 +1,52 @@
+package com.example.todolist.auth.service;
+
+import com.example.todolist.auth.security.jwt.JwtUtil;
+import com.example.todolist.global.dto.CommonResponse;
+import com.example.todolist.global.excetion.CustomException;
+import com.example.todolist.global.excetion.ErrorCode;
+import com.example.todolist.user.entity.User;
+import com.example.todolist.user.repository.UserRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class LogoutService {
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+
+    public LogoutService(UserRepository userRepository, JwtUtil jwtUtil) {
+        this.userRepository = userRepository;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Transactional
+    public CommonResponse<Void> logout(HttpServletRequest request) {
+
+        String token = jwtUtil.getJwtTokenFromHeader(request);
+        if (token == null || token.isEmpty()) {
+            throw new CustomException(ErrorCode.FALSE_TOKEN);
+        }
+
+        String username;
+        try {
+            username = jwtUtil.getUserInfoFromToken(token).getSubject();
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(ErrorCode.TOKEN_EXPIRATION);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USERNAME));
+
+        if (user.getTokenStore() != null && user.getTokenStore().getRefreshToken() != null) {
+            user.clearRefreshToken();
+        } else {
+            throw new CustomException(ErrorCode.FALSE_TOKEN);
+        }
+
+        return new CommonResponse<>("로그아웃 되었습니다.", 200, null);
+    }
+}

--- a/src/main/java/com/example/todolist/auth/service/SignupService.java
+++ b/src/main/java/com/example/todolist/auth/service/SignupService.java
@@ -1,0 +1,65 @@
+package com.example.todolist.auth.service;
+
+import com.example.todolist.auth.dto.SignupRequestDto;
+import com.example.todolist.auth.dto.SignupResponseDto;
+import com.example.todolist.global.excetion.CustomException;
+import com.example.todolist.global.excetion.ErrorCode;
+import com.example.todolist.user.entity.User;
+import com.example.todolist.user.entity.UserRole;
+import com.example.todolist.user.repository.UserRepository;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.regex.Pattern;
+
+@Service
+public class SignupService {
+
+    private static final Pattern PASSWORD_PATTERN = Pattern.compile(
+            "^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$"
+    );
+
+    private UserRepository userRepository;
+    private PasswordEncoder passwordEncoder;
+
+    public SignupService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Transactional
+    public SignupResponseDto signup(SignupRequestDto signupRequestDto) {
+        try{
+            validatePassword(signupRequestDto.getPassword());
+
+            String encodedPassword = passwordEncoder.encode(signupRequestDto.getPassword());
+
+            User user = User.builder()
+                    .username(signupRequestDto.getUsername())
+                    .password(encodedPassword)
+                    .email(signupRequestDto.getEmail())
+                    .role(UserRole.ROLE_USER)
+                    .build();
+
+            userRepository.save(user);
+
+            return SignupResponseDto.builder()
+                    .username(user.getUsername())
+                    .email(user.getEmail())
+                    .build();
+
+            } catch (DataIntegrityViolationException e) {
+                throw new CustomException(ErrorCode.DUPLICATE_USERNAME);
+            } catch (Exception e) {
+            throw new CustomException(ErrorCode.SIGNUP_FAILED);
+        }
+    }
+
+    private void validatePassword(String password) {
+        if (!PASSWORD_PATTERN.matcher(password).matches()) {
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
+        }
+    }
+}

--- a/src/main/java/com/example/todolist/auth/service/TokenService.java
+++ b/src/main/java/com/example/todolist/auth/service/TokenService.java
@@ -1,0 +1,41 @@
+package com.example.todolist.auth.service;
+
+import com.example.todolist.auth.security.jwt.JwtUtil;
+import com.example.todolist.global.excetion.CustomException;
+import com.example.todolist.global.excetion.ErrorCode;
+import com.example.todolist.user.entity.TokenStore;
+import com.example.todolist.user.entity.User;
+import com.example.todolist.user.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+
+    public TokenStore refreshAccessToken(String refreshTokenHeader) {
+        String refreshToken = refreshTokenHeader.replace("Bearer ", "");
+
+        if (!jwtUtil.isTokenValid(refreshToken)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
+        Claims claims = jwtUtil.getUserInfoFromToken(refreshToken);
+        String username = claims.getSubject();
+
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USERNAME));
+
+        if (!refreshToken.equals(user.getTokenStore().getRefreshToken())) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
+        String newAccessToken = jwtUtil.createToken(username, user.getRole(), JwtUtil.ACCESS_TOKEN_EXPIRATION);
+
+        return new TokenStore(newAccessToken ,refreshToken);
+    }
+}

--- a/src/main/java/com/example/todolist/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/todolist/global/GlobalExceptionHandler.java
@@ -1,0 +1,38 @@
+package com.example.todolist.global;
+
+import com.example.todolist.global.dto.CommonErrorResponse;
+import com.example.todolist.global.excetion.CustomException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<CommonErrorResponse> handleCustomException(final CustomException e) {
+        return ResponseEntity.status(e.getStatusCode()).body(
+                CommonErrorResponse.builder()
+                        .message(e.getMessage())
+                        .error(e.getStatusCode().getReasonPhrase())
+                        .statusCode(e.getStatusCode().value())
+                        .timestamp(LocalDateTime.now())
+                        .build()
+        );
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity handleValidationExceptions(MethodArgumentNotValidException ex) {
+        return ResponseEntity.status(ex.getStatusCode())
+                .body(CommonErrorResponse.builder()
+                        .message(ex.getBindingResult().getFieldError().getDefaultMessage())
+                        .error(HttpStatus.valueOf(ex.getStatusCode().value()).getReasonPhrase())
+                        .statusCode(ex.getStatusCode().value())
+                        .timestamp(LocalDateTime.now())
+                        .build());
+    }
+}

--- a/src/main/java/com/example/todolist/global/Timestamp.java
+++ b/src/main/java/com/example/todolist/global/Timestamp.java
@@ -1,0 +1,26 @@
+package com.example.todolist.global;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+
+@Getter
+public abstract class Timestamp {
+
+    @CreatedDate
+    @Column(updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/example/todolist/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/todolist/global/config/SwaggerConfig.java
@@ -1,0 +1,32 @@
+package com.example.todolist.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer").bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                .info(getInfo());
+    }
+
+    private Info getInfo() {
+        return new Info()
+                .title("ToDoList API")
+                .version("1.0")
+                .description("ToDoList API 문서");
+    }
+}

--- a/src/main/java/com/example/todolist/global/dto/CommonErrorResponse.java
+++ b/src/main/java/com/example/todolist/global/dto/CommonErrorResponse.java
@@ -1,0 +1,17 @@
+package com.example.todolist.global.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CommonErrorResponse {
+
+    private String message;
+    private String error;
+    private int statusCode;
+    private LocalDateTime timestamp;
+
+}

--- a/src/main/java/com/example/todolist/global/dto/CommonResponse.java
+++ b/src/main/java/com/example/todolist/global/dto/CommonResponse.java
@@ -1,0 +1,12 @@
+package com.example.todolist.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommonResponse <T> {
+    private String message;
+    private int statusCode;
+    private T result;
+}

--- a/src/main/java/com/example/todolist/global/excetion/CustomException.java
+++ b/src/main/java/com/example/todolist/global/excetion/CustomException.java
@@ -1,0 +1,19 @@
+package com.example.todolist.global.excetion;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomException extends RuntimeException {
+
+    private final HttpStatus statusCode;
+    private final String message;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.statusCode = errorCode.getStatus();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/src/main/java/com/example/todolist/global/excetion/ErrorCode.java
+++ b/src/main/java/com/example/todolist/global/excetion/ErrorCode.java
@@ -1,0 +1,31 @@
+package com.example.todolist.global.excetion;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD REQUEST"),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED"),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "NOT FOUND"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR"),
+
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다."),
+    TOKEN_EXPIRATION(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다. 재로그인 해주세요."),
+    NOT_SUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원되지 않는 JWT 토큰입니다."),
+    FALSE_TOKEN(HttpStatus.BAD_REQUEST, "잘못된 JWT 토큰입니다."),
+    HEADER_NOT_FOUND(HttpStatus.BAD_REQUEST, "헤더가 잘못되었거나 누락되었습니다."),
+    UNMATCHED_TOKEN(HttpStatus.BAD_REQUEST, "일치하지 않는 토큰입니다."),
+
+    NOT_FOUND_USERNAME(HttpStatus.NOT_FOUND, "유저를 찾을수 없습니다."),
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED,"잘못된권한입니다." ),
+    DUPLICATE_USERNAME(HttpStatus.BAD_REQUEST, "중복된 유저아이디입니다."),
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다." ),
+    SIGNUP_FAILED(HttpStatus.BAD_REQUEST, "회원가입에 실패하셨습니다."), 
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호는 최소 8자 이상, 15자 이하이며 알파벳 대소문자(a~z, A~Z), 숫자(0~9), 특수문자로 이루어져 있어야 합니다.");
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/example/todolist/user/entity/TokenStore.java
+++ b/src/main/java/com/example/todolist/user/entity/TokenStore.java
@@ -1,0 +1,38 @@
+package com.example.todolist.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Transient;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@Builder
+public class TokenStore {
+
+    @Column(name = "refresh_token", length = 500)
+    private String refreshToken;
+
+    @Transient
+    private String newAccessToken;
+
+    public TokenStore(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public TokenStore(String newAccessToken, String refreshToken) {
+        this.newAccessToken = newAccessToken;
+        this.refreshToken = refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void clearTokens() {
+        this.refreshToken = null;
+    }
+}

--- a/src/main/java/com/example/todolist/user/entity/User.java
+++ b/src/main/java/com/example/todolist/user/entity/User.java
@@ -1,0 +1,40 @@
+package com.example.todolist.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50, unique = true)
+    private String username;
+
+    @Column(nullable = false, length = 50, unique = true)
+    private String email;
+
+    @Column(nullable = false, length = 225)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role;
+
+    @Embedded
+    private TokenStore tokenStore;
+
+    public void clearRefreshToken() {
+        if (this.tokenStore != null) {
+            this.tokenStore.clearTokens();
+        }
+    }
+
+}

--- a/src/main/java/com/example/todolist/user/entity/UserRole.java
+++ b/src/main/java/com/example/todolist/user/entity/UserRole.java
@@ -1,0 +1,10 @@
+package com.example.todolist.user.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum UserRole {
+    ROLE_ADMIN,
+    ROLE_USER
+    ;
+}

--- a/src/main/java/com/example/todolist/user/repository/UserRepository.java
+++ b/src/main/java/com/example/todolist/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.example.todolist.user.repository;
+
+import com.example.todolist.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 spring.application.name=Todolist
-
+spring.profiles.active=dev


### PR DESCRIPTION
### 🚀 로그인, 회원가입, 로그아웃 기능 구현 완료

### ✅ 주요 구현 사항
- [x] **로그인 기능**: `username`, `password`를 요청 값으로 받아 JWT 토큰을 반환
- [x] **회원가입 기능**: `username`, `email`, `password`를 입력받아 사용자 등록
- [x] **로그아웃 기능**: 사용자의 리프레시 토큰을 삭제하여 로그아웃 처리

### 🔍 테스트 및 확인
- [x] **Swagger에서 로그인/회원가입/로그아웃 기능 정상 동작 확인**
- [x] **POST /api/auth/login** 요청 예시:
  ```json
  {
    "username": "testUser",
    "password": "testPassword"
  }
