### PR TITLE
Feat/#3 todo

### DIFF
--- a/src/main/java/com/example/todolist/auth/UserDetailsImpl.java
+++ b/src/main/java/com/example/todolist/auth/UserDetailsImpl.java
@@ -5,34 +5,40 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 
-public class UserDetailsImpl implements UserDetails {
-
-    private final User user;
+public class UserDetailsImpl implements UserDetails, Serializable {  // ✅ 직렬화 추가
+    private final Long userId;  // ✅ User 대신 ID만 저장
+    private final String username;
+    private final String password;
+    private final Collection<? extends GrantedAuthority> authorities;
 
     public UserDetailsImpl(User user) {
-        this.user = user;
+        this.userId = user.getId();
+        this.username = user.getUsername();
+        this.password = user.getPassword();
+        this.authorities = List.of(new SimpleGrantedAuthority(user.getRole().name()));
     }
 
-    public User getUser() {
-        return this.user;
-    }
-
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority(user.getRole().name()));
-    }
-
-    @Override
-    public String getPassword() {
-        return user.getPassword();
+    public Long getUserId() {
+        return userId;
     }
 
     @Override
     public String getUsername() {
-        return user.getUsername();
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
     }
 
     @Override

--- a/src/main/java/com/example/todolist/auth/UserDetailsImpl.java
+++ b/src/main/java/com/example/todolist/auth/UserDetailsImpl.java
@@ -9,8 +9,8 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 
-public class UserDetailsImpl implements UserDetails, Serializable {  // ✅ 직렬화 추가
-    private final Long userId;  // ✅ User 대신 ID만 저장
+public class UserDetailsImpl implements UserDetails, Serializable {
+    private final Long userId;
     private final String username;
     private final String password;
     private final Collection<? extends GrantedAuthority> authorities;

--- a/src/main/java/com/example/todolist/calendar/controller/CalendarController.java
+++ b/src/main/java/com/example/todolist/calendar/controller/CalendarController.java
@@ -42,4 +42,23 @@ public class CalendarController {
         CalendarResponseDto response = calendarService.getCalendarById(id);
         return ResponseEntity.ok(new CommonResponse<>("일정 조회 완료",200, response));
     }
+
+    @PutMapping("/update/{id}")
+    public ResponseEntity<CommonResponse<CalendarResponseDto>> updateCalendar(
+            @PathVariable Long id,
+            @RequestBody CalendarRequestDto calendarRequestDto,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ){
+        CalendarResponseDto response = calendarService.updateCalendarById(calendarRequestDto,userDetails ,id);
+        return ResponseEntity.ok(new CommonResponse<>("일정 수정 완료",200, response));
+    }
+
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<CommonResponse<CalendarResponseDto>> deleteCalendar(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ){
+        CalendarResponseDto response = calendarService.deleteCalendarById(userDetails ,id);
+        return ResponseEntity.ok(new CommonResponse<>("일정 삭제 완료",200, response));
+    }
 }

--- a/src/main/java/com/example/todolist/calendar/controller/CalendarController.java
+++ b/src/main/java/com/example/todolist/calendar/controller/CalendarController.java
@@ -8,10 +8,9 @@ import com.example.todolist.global.dto.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/calendar")
@@ -21,11 +20,26 @@ public class CalendarController {
     private final CalendarService calendarService;
 
     @PostMapping
-    public ResponseEntity<CommonResponse<CalendarResponseDto>> makecalendar(
+    public ResponseEntity<CommonResponse<CalendarResponseDto>> createcalendar(
             @RequestBody CalendarRequestDto calendarRequestDto,
             @AuthenticationPrincipal UserDetailsImpl userDetails
-    ){
-        CalendarResponseDto responseDto = calendarService.makecalendar(calendarRequestDto, userDetails);
+    ) {
+        CalendarResponseDto responseDto = calendarService.createCalendar(calendarRequestDto, userDetails);
         return ResponseEntity.ok(new CommonResponse<>("일정 생성 완료", 200, responseDto));
+    }
+
+    @GetMapping("/read")
+    public ResponseEntity<CommonResponse<List<CalendarResponseDto>>> readCalendar(
+    ){
+        List<CalendarResponseDto> responseDto =calendarService.getCalendar();
+        return ResponseEntity.ok(new CommonResponse<>("일정 조회 완료",200, responseDto));
+    }
+
+    @GetMapping("/read/{id}")
+    public ResponseEntity<CommonResponse<CalendarResponseDto>> readCalendarById(
+            @PathVariable Long id
+    ){
+        CalendarResponseDto response = calendarService.getCalendarById(id);
+        return ResponseEntity.ok(new CommonResponse<>("일정 조회 완료",200, response));
     }
 }

--- a/src/main/java/com/example/todolist/calendar/controller/CalendarController.java
+++ b/src/main/java/com/example/todolist/calendar/controller/CalendarController.java
@@ -28,14 +28,14 @@ public class CalendarController {
         return ResponseEntity.ok(new CommonResponse<>("일정 생성 완료", 200, responseDto));
     }
 
-    @GetMapping("/read")
+    @GetMapping("/readcalendar")
     public ResponseEntity<CommonResponse<List<CalendarResponseDto>>> readCalendar(
     ){
         List<CalendarResponseDto> responseDto =calendarService.getCalendar();
         return ResponseEntity.ok(new CommonResponse<>("일정 조회 완료",200, responseDto));
     }
 
-    @GetMapping("/read/{id}")
+    @GetMapping("/readcalendar/{id}")
     public ResponseEntity<CommonResponse<CalendarResponseDto>> readCalendarById(
             @PathVariable Long id
     ){
@@ -43,7 +43,7 @@ public class CalendarController {
         return ResponseEntity.ok(new CommonResponse<>("일정 조회 완료",200, response));
     }
 
-    @PutMapping("/update/{id}")
+    @PutMapping("/updatecalendar/{id}")
     public ResponseEntity<CommonResponse<CalendarResponseDto>> updateCalendar(
             @PathVariable Long id,
             @RequestBody CalendarRequestDto calendarRequestDto,
@@ -53,7 +53,7 @@ public class CalendarController {
         return ResponseEntity.ok(new CommonResponse<>("일정 수정 완료",200, response));
     }
 
-    @DeleteMapping("/delete/{id}")
+    @DeleteMapping("/deletecalendar/{id}")
     public ResponseEntity<CommonResponse<CalendarResponseDto>> deleteCalendar(
             @PathVariable Long id,
             @AuthenticationPrincipal UserDetailsImpl userDetails

--- a/src/main/java/com/example/todolist/calendar/dto/CalendarResponseDto.java
+++ b/src/main/java/com/example/todolist/calendar/dto/CalendarResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.todolist.calendar.dto;
 
+import com.example.todolist.calendar.entity.Calendar;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,4 +20,13 @@ public class CalendarResponseDto {
     private String location;
     private LocalDate startDate;
     private LocalDate endDate;
+
+    public CalendarResponseDto(Calendar calendar) {
+        this.id = calendar.getId();
+        this.title = calendar.getTitle();
+        this.description = calendar.getDescription();
+        this.location = calendar.getLocation();
+        this.startDate = calendar.getStartDate();
+        this.endDate = calendar.getEndDate();
+    }
 }

--- a/src/main/java/com/example/todolist/calendar/dto/CalendarResponseDto.java
+++ b/src/main/java/com/example/todolist/calendar/dto/CalendarResponseDto.java
@@ -13,6 +13,7 @@ import java.time.LocalDate;
 @NoArgsConstructor
 public class CalendarResponseDto {
 
+    private Long id;
     private String title;
     private String description;
     private String location;

--- a/src/main/java/com/example/todolist/calendar/entity/Calendar.java
+++ b/src/main/java/com/example/todolist/calendar/entity/Calendar.java
@@ -1,5 +1,6 @@
 package com.example.todolist.calendar.entity;
 
+import com.example.todolist.calendar.dto.CalendarRequestDto;
 import com.example.todolist.todo.entity.TodoLists;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -38,9 +39,17 @@ public class Calendar {
     @Column
     private String location;
 
-    @OneToMany(mappedBy = "calendar")
+    @OneToMany(mappedBy = "calendar", cascade = CascadeType.ALL)
     private List<TodoLists> todoLists = new ArrayList<>();
 
     @OneToMany(mappedBy = "calendar", cascade = CascadeType.ALL)
     private List<CalendarUser> calendarUsers;
+
+    public void updateCalendar(CalendarRequestDto requestDto) {
+        if (requestDto.getTitle() != null) this.title = requestDto.getTitle();
+        if (requestDto.getDescription() != null) this.description = requestDto.getDescription();
+        if (requestDto.getStartDate() != null) this.startDate = requestDto.getStartDate();
+        if (requestDto.getEndDate() != null) this.endDate = requestDto.getEndDate();
+        if (requestDto.getLocation() != null) this.location = requestDto.getLocation();
+    }
 }

--- a/src/main/java/com/example/todolist/calendar/entity/CalendarUser.java
+++ b/src/main/java/com/example/todolist/calendar/entity/CalendarUser.java
@@ -6,7 +6,6 @@ import lombok.*;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -18,10 +17,16 @@ public class CalendarUser {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "calendar_id")
+    @JoinColumn(name = "calendar_id", nullable = false)
     private Calendar calendar;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    public CalendarUser(Calendar calendar, User user) {
+        this.calendar = calendar;
+        this.user = user;
+    }
 }
+

--- a/src/main/java/com/example/todolist/calendar/service/CalendarService.java
+++ b/src/main/java/com/example/todolist/calendar/service/CalendarService.java
@@ -22,9 +22,7 @@ import java.util.List;
 public class CalendarService {
 
     private final CalendarRepository calendarRepository;
-
     private final UserRepository userRepository;
-
     private final CalendarUserRepository calendarUserRepository;
 
     @Transactional
@@ -69,6 +67,7 @@ public class CalendarService {
 
     @Transactional
     public CalendarResponseDto updateCalendarById(CalendarRequestDto calendarRequestDto, UserDetailsImpl userDetails, Long id) {
+
         Calendar calendar = calendarRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CALENDAR));
 

--- a/src/main/java/com/example/todolist/calendar/service/CalendarService.java
+++ b/src/main/java/com/example/todolist/calendar/service/CalendarService.java
@@ -7,11 +7,16 @@ import com.example.todolist.calendar.entity.Calendar;
 import com.example.todolist.calendar.entity.CalendarUser;
 import com.example.todolist.calendar.repository.CalendarRepository;
 import com.example.todolist.calendar.repository.CalendarUserRepository;
+import com.example.todolist.global.excetion.CustomException;
+import com.example.todolist.global.excetion.ErrorCode;
 import com.example.todolist.user.entity.User;
 import com.example.todolist.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -24,7 +29,7 @@ public class CalendarService {
     private final CalendarUserRepository calendarUserRepository;
 
     @Transactional
-    public CalendarResponseDto makecalendar(CalendarRequestDto calendarRequestDto,  UserDetailsImpl userDetails) {
+    public CalendarResponseDto createCalendar(CalendarRequestDto calendarRequestDto,  UserDetailsImpl userDetails) {
 
         User user = userDetails.getUser();
 
@@ -53,4 +58,38 @@ public class CalendarService {
                 .location(calendar.getLocation())
                 .build();
     }
+
+    @Transactional
+    public List<CalendarResponseDto> getCalendar() {
+        List<Calendar> calendars = calendarRepository.findAll();
+
+        return calendars.stream()
+                .map(calendar -> CalendarResponseDto.builder()
+                        .id(calendar.getId())
+                        .title(calendar.getTitle())
+                        .description(calendar.getDescription())
+                        .location(calendar.getLocation())
+                        .startDate(calendar.getStartDate())
+                        .endDate(calendar.getEndDate())
+                        .build()
+                )
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public CalendarResponseDto getCalendarById(Long id) {
+        Calendar calendar = calendarRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CALENDAR));
+
+        return CalendarResponseDto.builder()
+                .id(calendar.getId())  // ID 추가
+                .title(calendar.getTitle())
+                .description(calendar.getDescription())
+                .location(calendar.getLocation())
+                .startDate(calendar.getStartDate())
+                .endDate(calendar.getEndDate())
+                .build();
+    }
+
+
 }

--- a/src/main/java/com/example/todolist/global/excetion/ErrorCode.java
+++ b/src/main/java/com/example/todolist/global/excetion/ErrorCode.java
@@ -26,9 +26,14 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다." ),
     SIGNUP_FAILED(HttpStatus.BAD_REQUEST, "회원가입에 실패하셨습니다."), 
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호는 최소 8자 이상, 15자 이하이며 알파벳 대소문자(a~z, A~Z), 숫자(0~9), 특수문자로 이루어져 있어야 합니다."),
+
     NOT_FOUND_CALENDAR(HttpStatus.NOT_FOUND,"해당 일정이 존재하지 않습니다: " ),
-    NO_CALENDAR_UPDATE_PERMISSION(HttpStatus.NOT_FOUND,"일정 수정 권한이 없습니다." ),
+    NO_CALENDAR_UPDATE_PERMISSION(HttpStatus.UNAUTHORIZED,"일정 수정 권한이 없습니다." ),
     NO_CALENDAR_DELETE_PERMISSION(HttpStatus.UNAUTHORIZED,"일정 삭제 권한이 없습니다." ),
+
+    NOT_FOUND_TODO(HttpStatus.FORBIDDEN,"존재하지 않은 할 일입니다." ),
+    NO_TODO_UPDATE_PERMISSION(HttpStatus.UNAUTHORIZED,"할일 수정 권한이 없습니다." ),
+    NO_TODO_DELETE_PERMISSION(HttpStatus.UNAUTHORIZED,"할일 수정 권한이 없습니다." ),
     ;
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/todolist/global/excetion/ErrorCode.java
+++ b/src/main/java/com/example/todolist/global/excetion/ErrorCode.java
@@ -26,7 +26,9 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다." ),
     SIGNUP_FAILED(HttpStatus.BAD_REQUEST, "회원가입에 실패하셨습니다."), 
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호는 최소 8자 이상, 15자 이하이며 알파벳 대소문자(a~z, A~Z), 숫자(0~9), 특수문자로 이루어져 있어야 합니다."),
-    NOT_FOUND_CALENDAR(HttpStatus.NOT_FOUND,"해당 일정이 존재하지 않습니다: " )
+    NOT_FOUND_CALENDAR(HttpStatus.NOT_FOUND,"해당 일정이 존재하지 않습니다: " ),
+    NO_CALENDAR_UPDATE_PERMISSION(HttpStatus.NOT_FOUND,"일정 수정 권한이 없습니다." ),
+    NO_CALENDAR_DELETE_PERMISSION(HttpStatus.UNAUTHORIZED,"일정 삭제 권한이 없습니다." ),
     ;
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/todolist/global/excetion/ErrorCode.java
+++ b/src/main/java/com/example/todolist/global/excetion/ErrorCode.java
@@ -25,7 +25,9 @@ public enum ErrorCode {
     DUPLICATE_USERNAME(HttpStatus.BAD_REQUEST, "중복된 유저아이디입니다."),
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다." ),
     SIGNUP_FAILED(HttpStatus.BAD_REQUEST, "회원가입에 실패하셨습니다."), 
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호는 최소 8자 이상, 15자 이하이며 알파벳 대소문자(a~z, A~Z), 숫자(0~9), 특수문자로 이루어져 있어야 합니다.");
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호는 최소 8자 이상, 15자 이하이며 알파벳 대소문자(a~z, A~Z), 숫자(0~9), 특수문자로 이루어져 있어야 합니다."),
+    NOT_FOUND_CALENDAR(HttpStatus.NOT_FOUND,"해당 일정이 존재하지 않습니다: " )
+    ;
     private final HttpStatus status;
     private final String message;
 }

--- a/src/main/java/com/example/todolist/todo/controller/TodoController.java
+++ b/src/main/java/com/example/todolist/todo/controller/TodoController.java
@@ -17,11 +17,11 @@ public class TodoController {
     private final TodoService todoService;
 
     @PostMapping("/{calendarId}/todo")
-    public ResponseEntity<CommonResponse<TodoResponseDto>> maketodo(
+    public ResponseEntity<CommonResponse<TodoResponseDto>> createTodo(
             @PathVariable Long calendarId,
             @RequestBody TodoRequestDto todoRequestDto
     ){
-        TodoResponseDto responseDto = todoService.maketodo(calendarId,todoRequestDto);
+        TodoResponseDto responseDto = todoService.createTodo(calendarId,todoRequestDto);
         return ResponseEntity.ok(new CommonResponse<>("일정 생성완료", 200, responseDto));
     }
 }

--- a/src/main/java/com/example/todolist/todo/controller/TodoController.java
+++ b/src/main/java/com/example/todolist/todo/controller/TodoController.java
@@ -13,13 +13,13 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/todo/{calendarId}")
+@RequestMapping("/{calendarId}/todo")
 @RequiredArgsConstructor
 public class TodoController {
 
     private final TodoService todoService;
 
-    @PostMapping("todo")
+    @PostMapping
     public ResponseEntity<CommonResponse<TodoResponseDto>> createTodo(
             @PathVariable Long calendarId,
             @RequestBody TodoRequestDto todoRequestDto) {
@@ -27,19 +27,19 @@ public class TodoController {
         return ResponseEntity.ok(new CommonResponse<>("할 일 생성 완료", 200, responseDto));
     }
 
-    @GetMapping("/todos")
+    @GetMapping("/readtodo")
     public ResponseEntity<CommonResponse<List<TodoResponseDto>>> getTodos(@PathVariable Long calendarId) {
         List<TodoResponseDto> todos = todoService.getTodos(calendarId);
         return ResponseEntity.ok(new CommonResponse<>("할 일 목록 조회 완료", 200, todos));
     }
 
-    @GetMapping("/{todoId}")
+    @GetMapping("/readtodo/{todoId}")
     public ResponseEntity<CommonResponse<TodoResponseDto>> getTodoById(@PathVariable Long todoId) {
         TodoResponseDto todo = todoService.getTodoById(todoId);
         return ResponseEntity.ok(new CommonResponse<>("할 일 조회 완료", 200, todo));
     }
 
-    @PutMapping("/{todoId}")
+    @PutMapping("/updatetodo/{todoId}")
     public ResponseEntity<CommonResponse<TodoResponseDto>> updateTodo(
             @PathVariable Long todoId,
             @RequestBody TodoRequestDto todoRequestDto,
@@ -48,7 +48,7 @@ public class TodoController {
         return ResponseEntity.ok(new CommonResponse<>("할 일 수정 완료", 200, updatedTodo));
     }
 
-    @DeleteMapping("/{todoId}")
+    @DeleteMapping("/deletetodo/{todoId}")
     public ResponseEntity<CommonResponse<Void>> deleteTodo(
             @PathVariable Long todoId,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {

--- a/src/main/java/com/example/todolist/todo/controller/TodoController.java
+++ b/src/main/java/com/example/todolist/todo/controller/TodoController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/{calendarId}/todo")
+@RequestMapping("/api/{calendarId}/todo")
 @RequiredArgsConstructor
 public class TodoController {
 

--- a/src/main/java/com/example/todolist/todo/controller/TodoController.java
+++ b/src/main/java/com/example/todolist/todo/controller/TodoController.java
@@ -1,27 +1,58 @@
 package com.example.todolist.todo.controller;
 
+import com.example.todolist.auth.UserDetailsImpl;
 import com.example.todolist.global.dto.CommonResponse;
 import com.example.todolist.todo.dto.TodoRequestDto;
 import com.example.todolist.todo.dto.TodoResponseDto;
 import com.example.todolist.todo.service.TodoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
-@RequestMapping("/api/calendar")
+@RequestMapping("/todo")
 @RequiredArgsConstructor
 public class TodoController {
-
 
     private final TodoService todoService;
 
     @PostMapping("/{calendarId}/todo")
     public ResponseEntity<CommonResponse<TodoResponseDto>> createTodo(
             @PathVariable Long calendarId,
-            @RequestBody TodoRequestDto todoRequestDto
-    ){
-        TodoResponseDto responseDto = todoService.createTodo(calendarId,todoRequestDto);
-        return ResponseEntity.ok(new CommonResponse<>("일정 생성완료", 200, responseDto));
+            @RequestBody TodoRequestDto todoRequestDto) {
+        TodoResponseDto responseDto = todoService.createTodo(calendarId, todoRequestDto);
+        return ResponseEntity.ok(new CommonResponse<>("할 일 생성 완료", 200, responseDto));
+    }
+
+    @GetMapping("/{calendarId}/todos")
+    public ResponseEntity<CommonResponse<List<TodoResponseDto>>> getTodos(@PathVariable Long calendarId) {
+        List<TodoResponseDto> todos = todoService.getTodos(calendarId);
+        return ResponseEntity.ok(new CommonResponse<>("할 일 목록 조회 완료", 200, todos));
+    }
+
+    @GetMapping("/{todoId}")
+    public ResponseEntity<CommonResponse<TodoResponseDto>> getTodoById(@PathVariable Long todoId) {
+        TodoResponseDto todo = todoService.getTodoById(todoId);
+        return ResponseEntity.ok(new CommonResponse<>("할 일 조회 완료", 200, todo));
+    }
+
+    @PutMapping("/{todoId}")
+    public ResponseEntity<CommonResponse<TodoResponseDto>> updateTodo(
+            @PathVariable Long todoId,
+            @RequestBody TodoRequestDto todoRequestDto,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        TodoResponseDto updatedTodo = todoService.updateTodo(todoId, todoRequestDto, userDetails);
+        return ResponseEntity.ok(new CommonResponse<>("할 일 수정 완료", 200, updatedTodo));
+    }
+
+    @DeleteMapping("/{todoId}")
+    public ResponseEntity<CommonResponse<Void>> deleteTodo(
+            @PathVariable Long todoId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        todoService.deleteTodo(todoId, userDetails);
+        return ResponseEntity.ok(new CommonResponse<>("할 일 삭제 완료", 200, null));
     }
 }

--- a/src/main/java/com/example/todolist/todo/controller/TodoController.java
+++ b/src/main/java/com/example/todolist/todo/controller/TodoController.java
@@ -13,13 +13,13 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/todo")
+@RequestMapping("/todo/{calendarId}")
 @RequiredArgsConstructor
 public class TodoController {
 
     private final TodoService todoService;
 
-    @PostMapping("/{calendarId}/todo")
+    @PostMapping("todo")
     public ResponseEntity<CommonResponse<TodoResponseDto>> createTodo(
             @PathVariable Long calendarId,
             @RequestBody TodoRequestDto todoRequestDto) {
@@ -27,7 +27,7 @@ public class TodoController {
         return ResponseEntity.ok(new CommonResponse<>("할 일 생성 완료", 200, responseDto));
     }
 
-    @GetMapping("/{calendarId}/todos")
+    @GetMapping("/todos")
     public ResponseEntity<CommonResponse<List<TodoResponseDto>>> getTodos(@PathVariable Long calendarId) {
         List<TodoResponseDto> todos = todoService.getTodos(calendarId);
         return ResponseEntity.ok(new CommonResponse<>("할 일 목록 조회 완료", 200, todos));

--- a/src/main/java/com/example/todolist/todo/dto/TodoResponseDto.java
+++ b/src/main/java/com/example/todolist/todo/dto/TodoResponseDto.java
@@ -1,19 +1,30 @@
 package com.example.todolist.todo.dto;
 
 import com.example.todolist.global.Timestamp;
+import com.example.todolist.todo.entity.TodoLists;
 import lombok.*;
 
 import java.time.LocalDateTime;
 
-@Getter @Setter
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 public class TodoResponseDto extends Timestamp {
 
+    private Long id;
     private String title;
     private String description;
     private LocalDateTime startDate;
     private LocalDateTime dueDate;
     private String tag;
+
+    public TodoResponseDto(TodoLists todo) {
+        this.id = todo.getId();
+        this.title = todo.getTitle();
+        this.description = todo.getDescription();
+        this.tag = todo.getTag();
+        this.startDate = todo.getStartTime();
+        this.dueDate = todo.getDueTime();
+    }
 }

--- a/src/main/java/com/example/todolist/todo/dto/TodoResponseDto.java
+++ b/src/main/java/com/example/todolist/todo/dto/TodoResponseDto.java
@@ -1,8 +1,10 @@
 package com.example.todolist.todo.dto;
 
-import com.example.todolist.global.Timestamp;
 import com.example.todolist.todo.entity.TodoLists;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
@@ -10,7 +12,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class TodoResponseDto extends Timestamp {
+public class TodoResponseDto{
 
     private Long id;
     private String title;

--- a/src/main/java/com/example/todolist/todo/entity/TodoLists.java
+++ b/src/main/java/com/example/todolist/todo/entity/TodoLists.java
@@ -1,7 +1,6 @@
 package com.example.todolist.todo.entity;
 
 import com.example.todolist.calendar.entity.Calendar;
-import com.example.todolist.global.Timestamp;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,7 +14,7 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class TodoLists extends Timestamp {
+public class TodoLists {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/todolist/todo/entity/TodoLists.java
+++ b/src/main/java/com/example/todolist/todo/entity/TodoLists.java
@@ -38,5 +38,14 @@ public class TodoLists extends Timestamp {
     private String tag;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "calendar_id", nullable = false)
     private Calendar calendar;
+
+    public void updateTodo(String title, String description, String tag, LocalDateTime startTime, LocalDateTime dueTime) {
+        if (title != null) this.title = title;
+        if (description != null) this.description = description;
+        if (tag != null) this.tag = tag;
+        if (startTime != null) this.startTime = startTime;
+        if (dueTime != null) this.dueTime = dueTime;
+    }
 }

--- a/src/main/java/com/example/todolist/todo/repository/TodoRepository.java
+++ b/src/main/java/com/example/todolist/todo/repository/TodoRepository.java
@@ -5,7 +5,10 @@ import com.example.todolist.todo.entity.TodoLists;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface TodoRepository extends JpaRepository <TodoLists, Long> {
 
+    List<TodoLists> findByCalendarId(Long calendarId);
 }

--- a/src/main/java/com/example/todolist/todo/service/TodoService.java
+++ b/src/main/java/com/example/todolist/todo/service/TodoService.java
@@ -21,7 +21,7 @@ public class TodoService {
     private final CalendarRepository calendarRepository;
 
     @Transactional
-    public TodoResponseDto maketodo(Long calendarId ,TodoRequestDto todoRequestDto) {
+    public TodoResponseDto createTodo(Long calendarId ,TodoRequestDto todoRequestDto) {
 
         Calendar calendar = calendarRepository.findById(calendarId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));

--- a/src/main/java/com/example/todolist/todo/service/TodoService.java
+++ b/src/main/java/com/example/todolist/todo/service/TodoService.java
@@ -1,5 +1,6 @@
 package com.example.todolist.todo.service;
 
+import com.example.todolist.auth.UserDetailsImpl;
 import com.example.todolist.calendar.entity.Calendar;
 import com.example.todolist.calendar.repository.CalendarRepository;
 import com.example.todolist.global.excetion.CustomException;
@@ -12,21 +13,23 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class TodoService {
 
     private final TodoRepository todoRepository;
-
     private final CalendarRepository calendarRepository;
 
     @Transactional
-    public TodoResponseDto createTodo(Long calendarId ,TodoRequestDto todoRequestDto) {
+    public TodoResponseDto createTodo(Long calendarId, TodoRequestDto todoRequestDto) {
 
         Calendar calendar = calendarRepository.findById(calendarId)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CALENDAR));
 
         TodoLists todoLists = TodoLists.builder()
+                .calendar(calendar)
                 .title(todoRequestDto.getTitle())
                 .description(todoRequestDto.getDescription())
                 .tag(todoRequestDto.getTag())
@@ -36,12 +39,63 @@ public class TodoService {
 
         todoRepository.save(todoLists);
 
-        return TodoResponseDto.builder()
-                .title(todoLists.getTitle())
-                .description(todoLists.getDescription())
-                .tag(todoLists.getTag())
-                .startDate(todoLists.getStartTime())
-                .dueDate(todoLists.getDueTime())
-                .build();
+        return new TodoResponseDto(todoLists);
+    }
+
+    @Transactional
+    public List<TodoResponseDto> getTodos(Long calendarId) {
+        List<TodoLists> todos = todoRepository.findByCalendarId(calendarId);
+
+        return todos.stream()
+                .map(TodoResponseDto::new)
+                .toList();
+    }
+
+    @Transactional
+    public TodoResponseDto getTodoById(Long todoId) {
+        TodoLists todo = todoRepository.findById(todoId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_TODO));
+
+        return new TodoResponseDto(todo);
+    }
+
+    @Transactional
+    public TodoResponseDto updateTodo(Long todoId, TodoRequestDto todoRequestDto, UserDetailsImpl userDetails) {
+
+        TodoLists todo = todoRepository.findById(todoId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_TODO));
+
+        boolean isUserInCalendar = todo.getCalendar().getCalendarUsers().stream()
+                        .anyMatch(calendarUser -> calendarUser.getUser().getId().equals(userDetails.getUserId()));
+
+        if (!isUserInCalendar) {
+            throw new CustomException(ErrorCode.NO_TODO_UPDATE_PERMISSION);
+        }
+
+        todo.updateTodo(
+                todoRequestDto.getTitle(),
+                todoRequestDto.getDescription(),
+                todoRequestDto.getTag(),
+                todoRequestDto.getStartDate(),
+                todoRequestDto.getDueDate()
+        );
+
+        return new TodoResponseDto(todo);
+    }
+
+    @Transactional
+    public void deleteTodo(Long todoId, UserDetailsImpl userDetails) {
+        TodoLists todo = todoRepository.findById(todoId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_TODO));
+
+        boolean isUserInCalendar = todo.getCalendar().getCalendarUsers().stream()
+                .anyMatch(calendarUser -> calendarUser.getUser().getId().equals(userDetails.getUserId()));
+
+        if (!isUserInCalendar) {
+            throw new CustomException(ErrorCode.NO_TODO_DELETE_PERMISSION);
+        }
+
+        todoRepository.delete(todo);
     }
 }
+

--- a/src/main/java/com/example/todolist/user/entity/User.java
+++ b/src/main/java/com/example/todolist/user/entity/User.java
@@ -34,6 +34,7 @@ public class User extends Timestamp {
     @Column(nullable = false)
     private UserRole role;
 
+    @Setter
     @Embedded
     private TokenStore tokenStore;
 
@@ -42,5 +43,4 @@ public class User extends Timestamp {
             this.tokenStore.clearTokens();
         }
     }
-
 }

--- a/src/main/java/com/example/todolist/user/entity/User.java
+++ b/src/main/java/com/example/todolist/user/entity/User.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Getter @Setter @Builder
+@Getter @Builder
 @NoArgsConstructor @AllArgsConstructor
 public class User extends Timestamp {
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,28 @@
+## datasource
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${MYSQL_URL}
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PW}
+
+  ## JPA
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: true
+
+  ## Thymeleaf
+  thymeleaf:
+    cache: false
+    check-template-location: true
+    prefix: classpath:/templates/
+    suffix: .html
+
+## JWT
+jwt:
+  secret: ${JWT_SECRET_KEY}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,4 +2,4 @@ spring:
   application:
     name: Todolist
   profiles:
-    active: prod
+    active: dev

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,4 +2,4 @@ spring:
   application:
     name: Todolist
   profiles:
-    active: dev
+    active: prod


### PR DESCRIPTION
### 일정, 할 일 조회, 수정, 삭제 기능 구현완료

### 주요 구현 사항
- 일정(Calendar)
- [x] **일정 목록 조회 (Calendar 목록 조회)**: `calendarId`에 해당하는 일정 목록을 조회하는 기능 추가.
- [x] **일정 상세 조회 (Calendar 상세 조회)**: `calendarId`에 해당하는 일정 상세 조회하는 기능 추가.
- [x] **일정 수정 (Calendar 수정)**: `calendarId`에 해당하는 일정 정보를 수정하는 기능 추가.
- [x] **일정 삭제 (Calendar 삭제)**: `calendarId`에 해당하는 일정을 삭제하는 기능 추가.
- 할 일(Todo)
- [x] **할 일 목록 조회 (Todo 목록 조회)**: `calendarId` 및 `todoId`에 해당하는 할 일 목록을 조회하는 기능 추가.
- [x] **할 일 상세 조회 (Todo 상세 조회)**: `calendarId` 및 `todoId`에 해당하는 할 일 상세 조회하는 기능 추가.
- [x] **할 일 수정 (Todo 수정)**: `calendarId` 및 `todoId`에 해당하는 할 일 정보를 수정하는 기능 추가.
- [x] **할 일 삭제 (Todo 삭제)**: `calendarId` 및 `todoId`에 해당하는 할 일을 삭제하는 기능 추가.

### 테스트
- [x] **Swagger**를 통해 `Calendar` 및 `Todo`의 조회, 수정, 삭제 API가 정상적으로 동작하는지 확인.

## 일정(Calendar) API

### 1. 일정 목록 조회 (Calendar 조회)
- GET /api/calendar/readcalendar
- **설명**: 특정 `calendarId`에 해당하는 일정 정보를 조회하는 기능을 구현.

응답 예시

```json
{
    "title": "회의 일정",
    "description": "팀 회의",
    "location": "서울 사무실",
    "startDate": "2025-02-12",
    "endDate": "2025-02-12"
}
```

### 2. 일정 상세조회 (Calendar 상세 조회)
- GET /api/calendar/readcalendar/{calendarId}
- **설명**: 특정 `calendarId`에 해당하는 일정 정보를 조회하는 기능을 구현.

응답 예시

```json
{
    "title": "회의 일정",
    "description": "팀 회의",
    "location": "서울 사무실",
    "startDate": "2025-02-12",
    "endDate": "2025-02-12"
}
```

### 3. 일정 수정 (Calendar 수정)
- PUT /api/calendar/updatecalendar/{calendarId}
- 특정 일정 정보를 수정하는 기능 추가.

요청 본문 예시

```json
{
    "title": "수정된 회의 일정",
    "description": "팀 회의 변경",
    "location": "부산 사무실",
    "startDate": "2025-02-15",
    "endDate": "2025-02-15"
}
```

응답 예시

```json
{
    "message": "일정 수정 완료",
    "statusCode": 200,
    "result": {
        "title": "수정된 회의 일정",
        "description": "팀 회의 변경",
        "location": "부산 사무실",
        "startDate": "2025-02-15",
        "endDate": "2025-02-15"
    }
}
```
### 4. 일정 삭제 (Calendar 삭제)
- DELETE /api/calendar/deletecalendar/{calendarId}
- 특정 일정을 삭제하는 기능 추가.

응답 예시

```json
{
    "message": "일정 삭제 완료",
    "statusCode": 200
}
```

## 할 일(Todo) API
### 1. 할 일 목록 조회 (Todo 목록 조회)
- GET /api/calendar/{calendarId}/readtodo
- 특정 할 일의 상세 정보를 조회하는 기능 추가.

응답 예시

```json
{
    "title": "title1",
    "description": "description",
    "startDate": "1996-02-02T00:00:00",
    "dueDate": "1996-02-02T00:00:00",
    "tag": "기획"
}
```

### 2. 할 일상세 조회 (Todo 상세 조회)
- GET /api/calendar/{calendarId}/readtodo/{todoId}
- 특정 할 일의 상세 정보를 조회하는 기능 추가.

응답 예시

```json
{
    "title": "title1",
    "description": "description",
    "startDate": "1996-02-02T00:00:00",
    "dueDate": "1996-02-02T00:00:00",
    "tag": "기획"
}
```

### 3. 할 일 수정 (Todo 수정)
- PUT /api/calendar/{calendarId}/updatetodo/{todoId}
- 특정 할 일 정보를 수정하는 기능 추가.

요청 본문 예시

```json
{
    "title": "수정된 할 일",
    "description": "설명 변경",
    "startDate": "2025-03-01T10:00:00",
    "dueDate": "2025-03-05T18:00:00",
    "tag": "디자인"
}
```

응답 예시

```json
{
    "message": "할 일 수정 완료",
    "statusCode": 200,
    "result": {
        "title": "수정된 할 일",
        "description": "설명 변경",
        "startDate": "2025-03-01T10:00:00",
        "dueDate": "2025-03-05T18:00:00",
        "tag": "디자인"
    }
}
```

### 4. 할 일 삭제 (Todo 삭제)
- DELETE /api/calendar/{calendarId}/deletetodo/{todoId}
- 특정 할 일을 삭제하는 기능 추가.

응답 예시
```json
{
    "message": "할 일 삭제 완료",
    "statusCode": 200
}
```