### PR TITLE
Feat/#3 todo

### DIFF
--- a/src/main/java/com/example/todolist/auth/controller/AuthController.java
+++ b/src/main/java/com/example/todolist/auth/controller/AuthController.java
@@ -1,84 +1,84 @@
-    package com.example.todolist.auth.controller;
+package com.example.todolist.auth.controller;
 
-    import com.example.todolist.auth.dto.LoginRequestDto;
-    import com.example.todolist.auth.dto.LoginResponseDto;
-    import com.example.todolist.auth.dto.SignupRequestDto;
-    import com.example.todolist.auth.dto.SignupResponseDto;
-    import com.example.todolist.auth.service.LoginService;
-    import com.example.todolist.auth.service.LogoutService;
-    import com.example.todolist.auth.service.SignupService;
-    import com.example.todolist.global.dto.CommonResponse;
-    import com.example.todolist.global.excetion.CustomException;
-    import io.swagger.v3.oas.annotations.Operation;
-    import io.swagger.v3.oas.annotations.tags.Tag;
-    import jakarta.servlet.http.HttpServletRequest;
-    import jakarta.validation.Valid;
-    import lombok.RequiredArgsConstructor;
-    import org.springframework.http.HttpStatus;
-    import org.springframework.http.ResponseEntity;
-    import org.springframework.validation.BindingResult;
-    import org.springframework.web.bind.annotation.PostMapping;
-    import org.springframework.web.bind.annotation.RequestBody;
-    import org.springframework.web.bind.annotation.RequestMapping;
-    import org.springframework.web.bind.annotation.RestController;
+import com.example.todolist.auth.dto.LoginRequestDto;
+import com.example.todolist.auth.dto.LoginResponseDto;
+import com.example.todolist.auth.dto.SignupRequestDto;
+import com.example.todolist.auth.dto.SignupResponseDto;
+import com.example.todolist.auth.service.LoginService;
+import com.example.todolist.auth.service.LogoutService;
+import com.example.todolist.auth.service.SignupService;
+import com.example.todolist.global.dto.CommonResponse;
+import com.example.todolist.global.excetion.CustomException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-    @RestController
-    @RequestMapping("/api/auth")
-    @Tag(name = "Auth")
-    @RequiredArgsConstructor
-    public class AuthController {
+@RestController
+@RequestMapping("/api/auth")
+@Tag(name = "Auth")
+@RequiredArgsConstructor
+public class AuthController {
 
-        private final SignupService signupService;
+    private final SignupService signupService;
 
-        private final LoginService loginService;
+    private final LoginService loginService;
 
-        private final LogoutService logoutService;
+    private final LogoutService logoutService;
 
-        @PostMapping("/signup")
-        @Operation(summary = "회원가입", description = "회원가입 기능")
-        public ResponseEntity<CommonResponse<SignupResponseDto>> signup(
-                @Valid @RequestBody SignupRequestDto signupRequestDto,
-                BindingResult bindingResult
-        ) {
-            if (bindingResult.hasErrors()) {
-                return ResponseEntity.badRequest()
-                        .body(new CommonResponse<>(bindingResult.getAllErrors().get(0).getDefaultMessage(), 400, null));
-            }
-            SignupResponseDto responseDto = signupService.signup(signupRequestDto);
-            return ResponseEntity.ok(new CommonResponse<>("회원가입 성공", 200, responseDto));
+    @PostMapping("/signup")
+    @Operation(summary = "회원가입", description = "회원가입 기능")
+    public ResponseEntity<CommonResponse<SignupResponseDto>> signup(
+            @Valid @RequestBody SignupRequestDto signupRequestDto,
+            BindingResult bindingResult
+    ) {
+        if (bindingResult.hasErrors()) {
+            return ResponseEntity.badRequest()
+                    .body(new CommonResponse<>(bindingResult.getAllErrors().get(0).getDefaultMessage(), 400, null));
         }
+        SignupResponseDto responseDto = signupService.signup(signupRequestDto);
+        return ResponseEntity.ok(new CommonResponse<>("회원가입 성공", 200, responseDto));
+    }
 
-        @PostMapping("/login")
-        @Operation(summary = "로그인", description = "로그인 기능")
-        public ResponseEntity<CommonResponse<LoginResponseDto>> login(
-                @RequestBody LoginRequestDto loginRequestDto
-        ){
-            try {
-                LoginResponseDto responseDto = loginService.login(loginRequestDto);
-                CommonResponse<LoginResponseDto> response = new CommonResponse<>("로그인 성공", 200, responseDto);
-                return ResponseEntity.ok(response);
-            } catch (IllegalArgumentException e) {
-                CommonResponse<LoginResponseDto> response = new CommonResponse<>("잘못된 요청입니다.", 400, null);
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
-            } catch (Exception e) {
-                CommonResponse<LoginResponseDto> response = new CommonResponse<>("서버 오류가 발생했습니다.", 500, null);
-                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
-            }
-        }
-
-
-        @PostMapping("/logout")
-        @Operation(summary = "로그아웃", description = "로그아웃 기능")
-        public ResponseEntity<CommonResponse<Void>> logout(HttpServletRequest request) {
-            try {
-                CommonResponse<Void> response = logoutService.logout(request);
-                return ResponseEntity.ok(response);
-            } catch (CustomException e) {
-                CommonResponse<Void> response = new CommonResponse<>(e.getMessage(), e.getStatusCode().value(), null);
-                return ResponseEntity.status(e.getStatusCode()).body(response);
-            } catch (Exception e) {
-                CommonResponse<Void> response = new CommonResponse<>("로그아웃 실패", HttpStatus.INTERNAL_SERVER_ERROR.value(), null);
-                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
-            }
+    @PostMapping("/login")
+    @Operation(summary = "로그인", description = "로그인 기능")
+    public ResponseEntity<CommonResponse<LoginResponseDto>> login(
+            @RequestBody LoginRequestDto loginRequestDto
+    ){
+        try {
+            LoginResponseDto responseDto = loginService.login(loginRequestDto);
+            CommonResponse<LoginResponseDto> response = new CommonResponse<>("로그인 성공", 200, responseDto);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            CommonResponse<LoginResponseDto> response = new CommonResponse<>("잘못된 요청입니다.", 400, null);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        } catch (Exception e) {
+            CommonResponse<LoginResponseDto> response = new CommonResponse<>("서버 오류가 발생했습니다.", 500, null);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
         }
     }
+
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "로그아웃 기능")
+    public ResponseEntity<CommonResponse<Void>> logout(HttpServletRequest request) {
+        try {
+            CommonResponse<Void> response = logoutService.logout(request);
+            return ResponseEntity.ok(response);
+        } catch (CustomException e) {
+            CommonResponse<Void> response = new CommonResponse<>(e.getMessage(), e.getStatusCode().value(), null);
+            return ResponseEntity.status(e.getStatusCode()).body(response);
+        } catch (Exception e) {
+            CommonResponse<Void> response = new CommonResponse<>("로그아웃 실패", HttpStatus.INTERNAL_SERVER_ERROR.value(), null);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+        }
+    }
+}

--- a/src/main/java/com/example/todolist/auth/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/todolist/auth/security/filter/JwtAuthenticationFilter.java
@@ -71,7 +71,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
                 .refreshToken(refreshToken)
                 .build();
 
-        response.addHeader(JwtUtil.AUTHORIZATION_HEADER, "Bearer " + accessToken); // "Bearer " 추가
+        response.addHeader(JwtUtil.AUTHORIZATION_HEADER, accessToken);
         responseSetting(response, HttpServletResponse.SC_OK, loginResponseDto);
     }
 

--- a/src/main/java/com/example/todolist/auth/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/example/todolist/auth/security/filter/JwtAuthorizationFilter.java
@@ -32,7 +32,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
             if (token != null && jwtUtil.isTokenValid(token)) {
                 Claims claims = jwtUtil.getUserInfoFromToken(token);
-                String username = claims.getSubject(); // subject = username
+                String username = claims.getSubject();
 
                 UserDetails userDetails = userDetailsService.loadUserByUsername(username);
 

--- a/src/main/java/com/example/todolist/auth/service/LoginService.java
+++ b/src/main/java/com/example/todolist/auth/service/LoginService.java
@@ -43,7 +43,8 @@ public class LoginService {
 
 
         if (loginUser.getTokenStore() == null) {
-            loginUser.setTokenStore(new TokenStore(refreshToken));
+            TokenStore tokenStore = new TokenStore(refreshToken, loginUser);
+            loginUser.setTokenStore(tokenStore);
         } else {
             loginUser.getTokenStore().setRefreshToken(refreshToken);
         }

--- a/src/main/java/com/example/todolist/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/todolist/global/config/SwaggerConfig.java
@@ -3,6 +3,7 @@ package com.example.todolist.global.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +21,7 @@ public class SwaggerConfig {
 
         return new OpenAPI()
                 .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
                 .info(getInfo());
     }
 

--- a/src/main/java/com/example/todolist/global/excetion/ErrorCode.java
+++ b/src/main/java/com/example/todolist/global/excetion/ErrorCode.java
@@ -34,7 +34,8 @@ public enum ErrorCode {
     NOT_FOUND_TODO(HttpStatus.FORBIDDEN,"존재하지 않은 할 일입니다." ),
     NO_TODO_UPDATE_PERMISSION(HttpStatus.UNAUTHORIZED,"할일 수정 권한이 없습니다." ),
     NO_TODO_DELETE_PERMISSION(HttpStatus.UNAUTHORIZED,"할일 수정 권한이 없습니다." ),
-    ;
+    INVALID_TODO_START_DATE(HttpStatus.UNAUTHORIZED, "유효 하지 않은 시작일 입니다."),
+    INVALID_TODO_DUE_DATE(HttpStatus.UNAUTHORIZED, "유효 하지 않은 마감일 입니다.");
     private final HttpStatus status;
     private final String message;
 }

--- a/src/main/java/com/example/todolist/todo/controller/TodoController.java
+++ b/src/main/java/com/example/todolist/todo/controller/TodoController.java
@@ -48,6 +48,15 @@ public class TodoController {
         return ResponseEntity.ok(new CommonResponse<>("할 일 수정 완료", 200, updatedTodo));
     }
 
+    @PutMapping("/todos/{todoId}/toggle")
+    public ResponseEntity<CommonResponse<TodoResponseDto>> toggleTodo(
+            @PathVariable Long todoId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        TodoResponseDto updatedTodoToggle = todoService.updatedTodoToggle(todoId, userDetails);
+        return ResponseEntity.ok(new CommonResponse<>("할 일 수정 완료", 200, updatedTodoToggle));
+    }
+
+
     @DeleteMapping("/deletetodo/{todoId}")
     public ResponseEntity<CommonResponse<Void>> deleteTodo(
             @PathVariable Long todoId,

--- a/src/main/java/com/example/todolist/todo/controller/TodoController.java
+++ b/src/main/java/com/example/todolist/todo/controller/TodoController.java
@@ -48,7 +48,7 @@ public class TodoController {
         return ResponseEntity.ok(new CommonResponse<>("할 일 수정 완료", 200, updatedTodo));
     }
 
-    @PutMapping("/todos/{todoId}/toggle")
+    @PutMapping("/{todoId}/toggle")
     public ResponseEntity<CommonResponse<TodoResponseDto>> toggleTodo(
             @PathVariable Long todoId,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {

--- a/src/main/java/com/example/todolist/todo/dto/TodoRequestDto.java
+++ b/src/main/java/com/example/todolist/todo/dto/TodoRequestDto.java
@@ -16,4 +16,9 @@ public class TodoRequestDto {
     private LocalDateTime startDate;
     private LocalDateTime dueDate;
     private String tag;
+    private boolean isCompleted;
+
+    public boolean getIsCompleted() {
+        return isCompleted;
+    }
 }

--- a/src/main/java/com/example/todolist/todo/dto/TodoResponseDto.java
+++ b/src/main/java/com/example/todolist/todo/dto/TodoResponseDto.java
@@ -20,6 +20,7 @@ public class TodoResponseDto{
     private LocalDateTime startDate;
     private LocalDateTime dueDate;
     private String tag;
+    private boolean isCompleted;
 
     public TodoResponseDto(TodoLists todo) {
         this.id = todo.getId();
@@ -28,5 +29,6 @@ public class TodoResponseDto{
         this.tag = todo.getTag();
         this.startDate = todo.getStartTime();
         this.dueDate = todo.getDueTime();
+        this.isCompleted = todo.isCompleted();
     }
 }

--- a/src/main/java/com/example/todolist/todo/entity/TodoLists.java
+++ b/src/main/java/com/example/todolist/todo/entity/TodoLists.java
@@ -2,10 +2,7 @@ package com.example.todolist.todo.entity;
 
 import com.example.todolist.calendar.entity.Calendar;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -52,7 +49,11 @@ public class TodoLists {
         this.isCompleted = isCompleted;
     }
 
-    public  void toggleCompleted() {
+    public void toggleCompleted() {
         this.isCompleted = !this.isCompleted;
+    }
+
+    public void setCompleted(boolean isCompleted) {
+        this.isCompleted = isCompleted;
     }
 }

--- a/src/main/java/com/example/todolist/todo/entity/TodoLists.java
+++ b/src/main/java/com/example/todolist/todo/entity/TodoLists.java
@@ -40,11 +40,19 @@ public class TodoLists {
     @JoinColumn(name = "calendar_id", nullable = false)
     private Calendar calendar;
 
-    public void updateTodo(String title, String description, String tag, LocalDateTime startTime, LocalDateTime dueTime) {
+    @Column
+    private boolean isCompleted;
+
+    public void updateTodo(String title, String description, String tag, LocalDateTime startTime, LocalDateTime dueTime, boolean isCompleted) {
         if (title != null) this.title = title;
         if (description != null) this.description = description;
         if (tag != null) this.tag = tag;
         if (startTime != null) this.startTime = startTime;
         if (dueTime != null) this.dueTime = dueTime;
+        this.isCompleted = isCompleted;
+    }
+
+    public  void toggleCompleted() {
+        this.isCompleted = !this.isCompleted;
     }
 }

--- a/src/main/java/com/example/todolist/todo/service/TodoService.java
+++ b/src/main/java/com/example/todolist/todo/service/TodoService.java
@@ -93,6 +93,16 @@ public class TodoService {
         return new TodoResponseDto(todo);
     }
 
+    public TodoResponseDto updatedTodoToggle(Long todoId, UserDetailsImpl userDetails) {
+        TodoLists todo = todoRepository.findById(todoId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_TODO));
+
+        todo.setCompleted(true);
+        todoRepository.save(todo);
+
+        return new TodoResponseDto(todo);
+    }
+
     @Transactional
     public void deleteTodo(Long todoId, UserDetailsImpl userDetails) {
         TodoLists todo = todoRepository.findById(todoId)

--- a/src/main/java/com/example/todolist/todo/service/TodoService.java
+++ b/src/main/java/com/example/todolist/todo/service/TodoService.java
@@ -28,6 +28,14 @@ public class TodoService {
         Calendar calendar = calendarRepository.findById(calendarId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CALENDAR));
 
+        if(todoRequestDto.getStartDate().isBefore(calendar.getStartDate().atStartOfDay())){
+            throw new CustomException(ErrorCode.INVALID_TODO_START_DATE);
+        }
+
+        if(todoRequestDto.getDueDate().isAfter(calendar.getEndDate().atStartOfDay())){
+            throw new CustomException(ErrorCode.INVALID_TODO_DUE_DATE);
+        }
+
         TodoLists todoLists = TodoLists.builder()
                 .calendar(calendar)
                 .title(todoRequestDto.getTitle())
@@ -35,6 +43,7 @@ public class TodoService {
                 .tag(todoRequestDto.getTag())
                 .startTime(todoRequestDto.getStartDate())
                 .dueTime(todoRequestDto.getDueDate())
+                .isCompleted(false)
                 .build();
 
         todoRepository.save(todoLists);
@@ -77,7 +86,8 @@ public class TodoService {
                 todoRequestDto.getDescription(),
                 todoRequestDto.getTag(),
                 todoRequestDto.getStartDate(),
-                todoRequestDto.getDueDate()
+                todoRequestDto.getDueDate(),
+                todoRequestDto.getIsCompleted()
         );
 
         return new TodoResponseDto(todo);

--- a/src/main/java/com/example/todolist/todo/service/TodoService.java
+++ b/src/main/java/com/example/todolist/todo/service/TodoService.java
@@ -97,6 +97,13 @@ public class TodoService {
         TodoLists todo = todoRepository.findById(todoId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_TODO));
 
+        boolean isUserInCalendar = todo.getCalendar().getCalendarUsers().stream()
+                .anyMatch(calendarUser -> calendarUser.getUser().getId().equals(userDetails.getUserId()));
+
+        if (!isUserInCalendar) {
+            throw new CustomException(ErrorCode.NO_TODO_UPDATE_PERMISSION);
+        }
+
         todo.setCompleted(true);
         todoRepository.save(todo);
 

--- a/src/main/java/com/example/todolist/user/entity/TokenStore.java
+++ b/src/main/java/com/example/todolist/user/entity/TokenStore.java
@@ -1,34 +1,38 @@
 package com.example.todolist.user.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
-import jakarta.persistence.Transient;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 
-@Embeddable
+@Entity
 @Getter
+@Setter
 @NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class TokenStore {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter
     @Column(name = "refresh_token", length = 500)
     private String refreshToken;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
 
     @Transient
     private String newAccessToken;
 
-    public TokenStore(String refreshToken) {
+    public TokenStore(String refreshToken, User loginUser) {
         this.refreshToken = refreshToken;
+        this.user = loginUser;
     }
 
     public TokenStore(String newAccessToken, String refreshToken) {
         this.newAccessToken = newAccessToken;
-        this.refreshToken = refreshToken;
-    }
-
-    public void setRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
 

--- a/src/main/java/com/example/todolist/user/entity/User.java
+++ b/src/main/java/com/example/todolist/user/entity/User.java
@@ -35,8 +35,15 @@ public class User extends Timestamp {
     private UserRole role;
 
     @Setter
-    @Embedded
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private TokenStore tokenStore;
+
+    public void setTokenStore(TokenStore tokenStore) {
+        this.tokenStore = tokenStore;
+        if (tokenStore != null) {
+            tokenStore.setUser(this);
+        }
+    }
 
     public void clearRefreshToken() {
         if (this.tokenStore != null) {


### PR DESCRIPTION
## 일정, 할 일 조회, 수정, 삭제 기능 구현완료
### 주요 구현 사항
- 할 일(Todo)
- [x] 할 일 생성 시 일정(calendar) 내에 시작일과 종료일을 지정하도록 수정.
- [x] 할 일 완료상태를 토클형태로 처리 (기본 false 완료시 true)

 테스트
 Swagger를 통해  Todo의 조회, 수정, 삭제 API가 정상적으로 동작하는지 확인.
## 할일 (Todo) API
1. 할일 생성(Todo)
- POST /api/calendarId/todo
- 설명: 특정 calendarId에 해당하는 일정 정보를 조회하는 기능을 구현.
요쳥 예시

```json
{
    "title": "title1",
    "description": "description",
    "startDate": "2002-02-02T00:00:00",
    "dueDate": "2002-02-02T00:00:00",
    "tag": "기획"
}
```

응답 예시
성공

```json
{
    "message": "할 일 생성 완료",
    "statusCode": 200,
    "result": {
        "id": 1,
        "title": "title1",
        "description": "description",
        "startDate": "2025-02-12T00:00:00",
        "dueDate": "2025-02-12T00:00:00",
        "tag": "기획",
        "completed": false
    }
}
```

실패

```json
{
    "message": "유효 하지 않은 시작일 입니다.",
    "error": "Unauthorized",
    "statusCode": 401,
    "timestamp": "2025-02-14T22:04:50.1950257"
}
```

2. 할일 토글
- PUT /api/calendarId/todo/{todoId}/toggle
- 설명: 특정 todoId에 해당하는 할일의 상태를 변경( false, true )

```json
{
    "message": "할 일 수정 완료",
    "statusCode": 200,
    "result": {
        "id": 1,
        "title": "title1",
        "description": "description",
        "startDate": "2025-02-12T00:00:00",
        "dueDate": "2025-02-12T00:00:00",
        "tag": "기획",
        "completed": true // 변경(false -> true)
    }
}
```