### PR TITLE
feat 일정 초대 기능 구현 (대기, 수락, 거절 가능)

### DIFF
--- a/src/main/java/com/example/todolist/calendar/controller/CalendarUserController.java
+++ b/src/main/java/com/example/todolist/calendar/controller/CalendarUserController.java
@@ -1,0 +1,46 @@
+package com.example.todolist.calendar.controller;
+
+import com.example.todolist.calendar.dto.CalendarUserResponseDto;
+import com.example.todolist.calendar.entity.InviteStatus;
+import com.example.todolist.calendar.service.CalendarUserService;
+import com.example.todolist.global.dto.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/calendar/{calendarId}/invite")
+@RequiredArgsConstructor
+public class CalendarUserController {
+
+    private final CalendarUserService calendarUserService;
+
+    @PostMapping
+    public ResponseEntity<CommonResponse<CalendarUserResponseDto>> inviteUser(
+            @PathVariable Long calendarId,
+            @RequestParam String username
+    ){
+        CalendarUserResponseDto response = calendarUserService.inviteUserToCalendar(calendarId, username);
+        return ResponseEntity.ok(new CommonResponse<>("초대 성공",200,response));
+    }
+
+    @PutMapping("/{inviteId}")
+    public ResponseEntity<CommonResponse<CalendarUserResponseDto>> respondToInvite(
+            @PathVariable Long calendarId,
+            @PathVariable Long inviteId,
+            @RequestParam InviteStatus status
+    ) {
+        CalendarUserResponseDto response = calendarUserService.respondToInvite(inviteId, status);
+        return ResponseEntity.ok(new CommonResponse<>("초대 응답 완료", 200, response));
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<CommonResponse<List<CalendarUserResponseDto>>> getInvitesByCalendar(
+            @PathVariable Long calendarId
+    ) {
+        List<CalendarUserResponseDto> response = calendarUserService.getInvitesByCalendar(calendarId);
+        return ResponseEntity.ok(new CommonResponse<>("초대 목록 조회 성공", 200, response));
+    }
+}

--- a/src/main/java/com/example/todolist/calendar/dto/CalendarResponseDto.java
+++ b/src/main/java/com/example/todolist/calendar/dto/CalendarResponseDto.java
@@ -1,6 +1,7 @@
 package com.example.todolist.calendar.dto;
 
 import com.example.todolist.calendar.entity.Calendar;
+import com.example.todolist.calendar.entity.InviteStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,6 +21,7 @@ public class CalendarResponseDto {
     private String location;
     private LocalDate startDate;
     private LocalDate endDate;
+    private InviteStatus inviteStatus;
 
     public CalendarResponseDto(Calendar calendar) {
         this.id = calendar.getId();
@@ -28,5 +30,15 @@ public class CalendarResponseDto {
         this.location = calendar.getLocation();
         this.startDate = calendar.getStartDate();
         this.endDate = calendar.getEndDate();
+    }
+
+    public CalendarResponseDto(Calendar calendar, InviteStatus inviteStatus) {
+        this.id = calendar.getId();
+        this.title = calendar.getTitle();
+        this.description = calendar.getDescription();
+        this.location = calendar.getLocation();
+        this.startDate = calendar.getStartDate();
+        this.endDate = calendar.getEndDate();
+        this.inviteStatus = inviteStatus;
     }
 }

--- a/src/main/java/com/example/todolist/calendar/dto/CalendarUserResponseDto.java
+++ b/src/main/java/com/example/todolist/calendar/dto/CalendarUserResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.todolist.calendar.dto;
+
+import com.example.todolist.calendar.entity.InviteStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CalendarUserResponseDto {
+    private Long id;
+    private Long calendarId;
+    private Long userId;
+    private InviteStatus status;
+}

--- a/src/main/java/com/example/todolist/calendar/entity/CalendarUser.java
+++ b/src/main/java/com/example/todolist/calendar/entity/CalendarUser.java
@@ -24,9 +24,23 @@ public class CalendarUser {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private InviteStatus inviteStatus = InviteStatus.PENDING;
+
     public CalendarUser(Calendar calendar, User user) {
         this.calendar = calendar;
         this.user = user;
+    }
+
+    public CalendarUser(Calendar calendar, User invitedUser, InviteStatus inviteStatus) {
+        this.calendar = calendar;
+        this.user = invitedUser;
+        this.inviteStatus = inviteStatus;
+    }
+
+    public void updateInviteStatus(InviteStatus status) {
+        this.inviteStatus = status;
     }
 }
 

--- a/src/main/java/com/example/todolist/calendar/entity/InviteStatus.java
+++ b/src/main/java/com/example/todolist/calendar/entity/InviteStatus.java
@@ -1,0 +1,7 @@
+package com.example.todolist.calendar.entity;
+
+public enum InviteStatus {
+    PENDING,
+    ACCEPTED,
+    DECLINED
+}

--- a/src/main/java/com/example/todolist/calendar/repository/CalendarUserRepository.java
+++ b/src/main/java/com/example/todolist/calendar/repository/CalendarUserRepository.java
@@ -1,6 +1,9 @@
 package com.example.todolist.calendar.repository;
 
+import com.example.todolist.calendar.entity.Calendar;
 import com.example.todolist.calendar.entity.CalendarUser;
+import com.example.todolist.calendar.entity.InviteStatus;
+import com.example.todolist.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,5 +11,12 @@ import java.util.List;
 
 @Repository
 public interface CalendarUserRepository extends JpaRepository<CalendarUser, Long> {
+
     List<CalendarUser> findByUser_Id(Long userId);
+
+    boolean existsByCalendarAndUser(Calendar calendar, User invitedUser);
+
+    List<CalendarUser> findByCalendar(Calendar calendar);
+
+    List<CalendarUser> findByUser_IdAndInviteStatus(Long userId, InviteStatus inviteStatus);
 }

--- a/src/main/java/com/example/todolist/calendar/service/CalendarUserService.java
+++ b/src/main/java/com/example/todolist/calendar/service/CalendarUserService.java
@@ -1,0 +1,85 @@
+package com.example.todolist.calendar.service;
+
+import com.example.todolist.calendar.dto.CalendarUserResponseDto;
+import com.example.todolist.calendar.entity.Calendar;
+import com.example.todolist.calendar.entity.CalendarUser;
+import com.example.todolist.calendar.entity.InviteStatus;
+import com.example.todolist.calendar.repository.CalendarRepository;
+import com.example.todolist.calendar.repository.CalendarUserRepository;
+import com.example.todolist.global.excetion.CustomException;
+import com.example.todolist.global.excetion.ErrorCode;
+import com.example.todolist.user.entity.User;
+import com.example.todolist.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CalendarUserService {
+
+    private final CalendarUserRepository calendarUserRepository;
+    private final UserRepository userRepository;
+    private final CalendarRepository calendarRepository;
+
+    @Transactional
+    public CalendarUserResponseDto inviteUserToCalendar(Long calendarId, String username) {
+        Calendar calendar = calendarRepository.findById(calendarId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CALENDAR));
+
+        User invitedUser = userRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USERNAME));
+
+        if (calendarUserRepository.existsByCalendarAndUser(calendar, invitedUser)) {
+            throw new CustomException(ErrorCode.IS_EXISTS);
+        }
+
+        CalendarUser invite = new CalendarUser(calendar, invitedUser, InviteStatus.PENDING);
+        CalendarUser savedInvite = calendarUserRepository.save(invite);
+
+        return CalendarUserResponseDto.builder()
+                .id(savedInvite.getId())
+                .calendarId(savedInvite.getCalendar().getId())
+                .userId(invitedUser.getId())
+                .status(savedInvite.getInviteStatus())
+                .build();
+    }
+
+    @Transactional
+    public CalendarUserResponseDto respondToInvite(Long inviteId, InviteStatus status) {
+        CalendarUser invite = calendarUserRepository.findById(inviteId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_INVITE));
+
+        if (invite.getInviteStatus() != InviteStatus.PENDING) {
+            throw new CustomException(ErrorCode.ALREADY_RESPONDED);
+        }
+
+        invite.updateInviteStatus(status);
+
+        return CalendarUserResponseDto.builder()
+                .id(invite.getId())
+                .calendarId(invite.getCalendar().getId())
+                .userId(invite.getUser().getId())
+                .status(invite.getInviteStatus())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<CalendarUserResponseDto> getInvitesByCalendar(Long calendarId) {
+        Calendar calendar = calendarRepository.findById(calendarId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CALENDAR));
+
+        List<CalendarUser> invites = calendarUserRepository.findByCalendar(calendar);
+
+        return invites.stream()
+                .map(invite -> CalendarUserResponseDto.builder()
+                        .id(invite.getId())
+                        .calendarId(calendarId)
+                        .userId(invite.getUser().getId())
+                        .status(invite.getInviteStatus())
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/com/example/todolist/global/excetion/ErrorCode.java
+++ b/src/main/java/com/example/todolist/global/excetion/ErrorCode.java
@@ -37,7 +37,13 @@ public enum ErrorCode {
     NO_TODO_DELETE_PERMISSION(HttpStatus.UNAUTHORIZED,"할일 수정 권한이 없습니다." ),
     INVALID_TODO_START_DATE(HttpStatus.UNAUTHORIZED, "유효 하지 않은 시작일 입니다."),
     INVALID_TODO_DUE_DATE(HttpStatus.UNAUTHORIZED, "유효 하지 않은 마감일 입니다."),
-;
+
+    IS_EXISTS(HttpStatus.BAD_REQUEST,"이미 초대된 사용자입니다" ),
+    NOT_FOUND_INVITE(HttpStatus.NOT_FOUND, "초대 정보를 찾을 수 없습니다."),
+    ALREADY_RESPONDED(HttpStatus.BAD_REQUEST, "이미 응답한 초대입니다."),
+    CANNOT_CANCEL(HttpStatus.BAD_REQUEST, "수락/거절된 초대는 취소할 수 없습니다.");
+
+    ;
     private final HttpStatus status;
     private final String message;
 }


### PR DESCRIPTION
## 초대(Invite) 기능 추가
### 주요 구현 사항
일정(Calendar)
- 일정(Calendar)에 사용자를 초대하는 기능을 구현
- 초대된 사용자는 초대 상태(PENDING, ACCEPTED, DECLINED)를 가짐
- 초대받은 사용자는 응답(수락/거절)할 수 있음
- 일정 조회 시, 초대 상태가 ACCEPTED인 사용자만 일정 조회 가능
- 일정 생성 시 기본 ACCEPTED로 생성되게 변경 (본인 생성일정은 ACCEPTED상태)
- PENDING 상태인 일정은 프론트에서 별도로 필터링하여 표시 가능 예정

테스트
- Swagger를 통해 Todo의 조회, 수정, 삭제 API가 정상적으로 동작하는지 확인.
## 구현된 API 목록
 1. 초대 생성 (사용자 초대하기)
- POST /api/calendar/{calendarId}/invite?username={username}
- 설명: 일정에 사용자를 초대하며, 기본 상태는 PENDING

응답 예

``` json
{
    "message": "초대 성공",
    "statusCode": 200,
    "result": {
        "id": 1,
        "calendarId": 5,
        "userId": 12,
        "status": "PENDING"
    }
}
```

2. 초대 응답 (수락 또는 거절)
- PUT /api/calendar/{calendarId}/invite/{inviteId}?status={ACCEPTED or DECLINED}
- 설명: 초대를 ACCEPTED(수락) 또는 DECLINED(거절)로 변경

응답 예시

```json
{
    "message": "초대 응답 완료",
    "statusCode": 200,
    "result": {
        "id": 3,
        "calendarId": 5,
        "userId": 12,
        "status": "ACCEPTED"
    }
}
```

3. 초대 목록 조회 (특정 일정의 초대된 사용자 목록)
- GET /api/calendar/{calendarId}/invite/list
- 설명: 특정 일정(calendarId)에 초대된 사용자 목록을 조회

응답 예시
```json
{
    "message": "초대 목록 조회 성공",
    "statusCode": 200,
    "result": [
        {
            "id": 1,
            "calendarId": 5,
            "userId": 12,
            "status": "PENDING"
        },
        {
            "id": 2,
            "calendarId": 5,
            "userId": 15,
            "status": "ACCEPTED"
        }
    ]
}
```